### PR TITLE
add node version constraint to codemods

### DIFF
--- a/src/get-applicable-codemods.js
+++ b/src/get-applicable-codemods.js
@@ -7,12 +7,15 @@ module.exports = function getApplicableCodemods(options) {
   let projectType = options.projectType;
   let startVersion = options.startVersion;
 
+  let nodeVersion = utils.getNodeVersion();
+
   return utils.getCodemods().then(codemods => {
     return Object.keys(codemods).filter(codemod => {
       codemod = codemods[codemod];
       let isVersionInRange = semver.gte(startVersion, codemod.version);
       let isCorrectProjectType = codemod.projectTypes.indexOf(projectType) !== -1;
-      return isVersionInRange && isCorrectProjectType;
+      let isNodeVersionInRange = semver.gte(nodeVersion, codemod.nodeVersion);
+      return isVersionInRange && isCorrectProjectType && isNodeVersionInRange;
     }).reduce((applicableCodemods, codemod) => {
       applicableCodemods[codemod] = codemods[codemod];
       return applicableCodemods;

--- a/src/get-codemods.js
+++ b/src/get-codemods.js
@@ -2,7 +2,7 @@
 
 const https = require('https');
 
-const url = 'https://rawgit.com/ember-cli/ember-cli-update-codemods-manifest/v1/manifest.json';
+const url = 'https://rawgit.com/ember-cli/ember-cli-update-codemods-manifest/v2/manifest.json';
 
 module.exports = function getCodemods() {
   return new Promise((resolve, reject) => {

--- a/src/get-node-version.js
+++ b/src/get-node-version.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = function getNodeVersion() {
+  return process.version.substr(1);
+};

--- a/src/utils.js
+++ b/src/utils.js
@@ -3,4 +3,5 @@
 module.exports.run = require('./run');
 module.exports.npx = require('./npx');
 module.exports.getCodemods = require('./get-codemods');
+module.exports.getNodeVersion = require('./get-node-version');
 module.exports.opn = require('opn');

--- a/test/unit/get-applicable-codemods-test.js
+++ b/test/unit/get-applicable-codemods-test.js
@@ -8,11 +8,13 @@ const getApplicableCodemods = require('../../src/get-applicable-codemods');
 describe('Unit - getApplicableCodemods', function() {
   let sandbox;
   let getCodemods;
+  let getNodeVersion;
 
   beforeEach(function() {
     sandbox = sinon.sandbox.create();
 
     getCodemods = sandbox.stub(utils, 'getCodemods');
+    getNodeVersion = sandbox.stub(utils, 'getNodeVersion');
   });
 
   afterEach(function() {
@@ -23,9 +25,12 @@ describe('Unit - getApplicableCodemods', function() {
     getCodemods.resolves({
       testCodemod: {
         version: '0.0.1',
-        projectTypes: ['testProjectType']
+        projectTypes: ['testProjectType'],
+        nodeVersion: '4.0.0'
       }
     });
+
+    getNodeVersion.returns('4.0.0');
 
     return getApplicableCodemods({
       projectType: 'testProjectType',
@@ -34,7 +39,8 @@ describe('Unit - getApplicableCodemods', function() {
       expect(codemods).to.deep.equal({
         testCodemod: {
           version: '0.0.1',
-          projectTypes: ['testProjectType']
+          projectTypes: ['testProjectType'],
+          nodeVersion: '4.0.0'
         }
       });
     });
@@ -44,9 +50,12 @@ describe('Unit - getApplicableCodemods', function() {
     getCodemods.resolves({
       testCodemod: {
         version: '0.0.1',
-        projectTypes: ['testProjectType2']
+        projectTypes: ['testProjectType2'],
+        nodeVersion: '4.0.0'
       }
     });
+
+    getNodeVersion.returns('4.0.0');
 
     return getApplicableCodemods({
       projectType: 'testProjectType1',
@@ -60,9 +69,31 @@ describe('Unit - getApplicableCodemods', function() {
     getCodemods.resolves({
       testCodemod: {
         version: '0.0.2',
-        projectTypes: ['testProjectType']
+        projectTypes: ['testProjectType'],
+        nodeVersion: '4.0.0'
       }
     });
+
+    getNodeVersion.returns('4.0.0');
+
+    return getApplicableCodemods({
+      projectType: 'testProjectType',
+      startVersion: '0.0.1'
+    }).then(codemods => {
+      expect(codemods).to.deep.equal({});
+    });
+  });
+
+  it('excludes wrong node version', function() {
+    getCodemods.resolves({
+      testCodemod: {
+        version: '0.0.1',
+        projectTypes: ['testProjectType'],
+        nodeVersion: '6.0.0'
+      }
+    });
+
+    getNodeVersion.returns('4.0.0');
 
     return getApplicableCodemods({
       projectType: 'testProjectType',

--- a/test/unit/get-dry-run-stats-test.js
+++ b/test/unit/get-dry-run-stats-test.js
@@ -31,17 +31,22 @@ describe('Unit - getDryRunStats', function() {
     sandbox.stub(utils, 'getCodemods').resolves({
       testCodemod1: {
         version: '0.0.1',
-        projectTypes: ['testProjectType']
+        projectTypes: ['testProjectType'],
+        nodeVersion: '4.0.0'
       },
       testCodemod2: {
         version: '0.0.1',
-        projectTypes: ['testProjectType']
+        projectTypes: ['testProjectType'],
+        nodeVersion: '4.0.0'
       },
       testCodemod3: {
         version: '0.0.2',
-        projectTypes: ['testProjectType']
+        projectTypes: ['testProjectType'],
+        nodeVersion: '4.0.0'
       }
     });
+
+    sandbox.stub(utils, 'getNodeVersion').returns('4.0.0');
 
     return getDryRunStats({
       projectType: 'testProjectType',

--- a/test/unit/run-codemods-test.js
+++ b/test/unit/run-codemods-test.js
@@ -15,6 +15,7 @@ describe('Unit - runCodemods', function() {
     sandbox = sinon.sandbox.create();
 
     getCodemods = sandbox.stub(utils, 'getCodemods');
+    sandbox.stub(utils, 'getNodeVersion').returns('4.0.0');
     npx = sandbox.stub(utils, 'npx').resolves();
     run = sandbox.stub(utils, 'run').resolves();
   });
@@ -28,6 +29,7 @@ describe('Unit - runCodemods', function() {
       testCodemod: {
         version: '0.0.1',
         projectTypes: ['testProjectType'],
+        nodeVersion: '4.0.0',
         commands: [
           'test command'
         ]
@@ -49,6 +51,7 @@ describe('Unit - runCodemods', function() {
       testCodemod: {
         version: '0.0.1',
         projectTypes: ['testProjectType'],
+        nodeVersion: '4.0.0',
         commands: [
           'test command 1',
           'test command 2'


### PR DESCRIPTION
This will allow us to merge https://github.com/ember-cli/ember-cli-update-codemods-manifest/pull/1 without waiting for node 4 end-of-life.