### PR TITLE
chore(update): removes Greenkeeper ref

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ node_js:
 branches:
   only:
   - master
-  - /^greenkeeper\/.*$/
   # npm version tags
   - /^v\d+\.\d+\.\d+$/
 cache:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # ember-cli-update
 
-[![Greenkeeper badge](https://badges.greenkeeper.io/ember-cli/ember-cli-update.svg)](https://greenkeeper.io/)
 [![npm version](https://badge.fury.io/js/ember-cli-update.svg)](https://badge.fury.io/js/ember-cli-update)
 [![Build Status](https://travis-ci.org/ember-cli/ember-cli-update.svg?branch=master)](https://travis-ci.org/ember-cli/ember-cli-update)
 [![Build status](https://ci.appveyor.com/api/projects/status/iguxxyxkiu9kyeyo/branch/master?svg=true)](https://ci.appveyor.com/project/embercli/ember-cli-update/branch/master)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,6 @@ environment:
 branches:
   only:
     - master
-    - /^greenkeeper\/.*$/
 
 matrix:
   allow_failures:


### PR DESCRIPTION
Hi! Can't wait to use this repo more. 

At a quick glance, it looks like Greenkeeper is no longer used. This PR removes Greenkeeper refs.