### PR TITLE
add createCustomDiff option

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ ember-cli-update --run-codemods
 | --compare-only | Show the changes between different versions without updating | Boolean | | false |
 | --dry-run | Show what would happen without actually doing it | Boolean | | false |
 | --list-codemods | List available codemods | Boolean | | false |
+| --create-custom-diff | Create a personal diff instead of using an output repo | Boolean | | false |
 
 ## Power User Guide
 

--- a/bin/ember-cli-update.js
+++ b/bin/ember-cli-update.js
@@ -15,6 +15,7 @@ const reset = argv['reset'];
 const compareOnly = argv['compare-only'];
 const dryRun = argv['dry-run'];
 const listCodemods = argv['list-codemods'];
+const createCustomDiff = argv['create-custom-diff'];
 
 // Displays a message on the terminal if a new version of the package is available.
 const updateNotifier = require('update-notifier');
@@ -39,7 +40,8 @@ emberCliUpdate({
   reset,
   compareOnly,
   dryRun,
-  listCodemods
+  listCodemods,
+  createCustomDiff
 }).then(message => {
   if (message) {
     console.log(message);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1889,7 +1889,7 @@
         },
         "external-editor": {
           "version": "1.1.1",
-          "resolved": "http://registry.npmjs.org/external-editor/-/external-editor-1.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-1.1.1.tgz",
           "integrity": "sha1-Etew24UPf/fnCBuvQAVwAGDEYAs=",
           "dev": true,
           "requires": {
@@ -1922,7 +1922,7 @@
           "dependencies": {
             "chalk": {
               "version": "1.1.3",
-              "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
               "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
               "dev": true,
               "requires": {
@@ -2062,7 +2062,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/cpr/-/cpr-3.0.1.tgz",
       "integrity": "sha1-uaVQOLfNgaNcF7l2GJW9hJau8eU=",
-      "dev": true,
       "requires": {
         "graceful-fs": "^4.1.5",
         "minimist": "^1.2.0",
@@ -3101,7 +3100,7 @@
     },
     "express": {
       "version": "4.16.3",
-      "resolved": "http://registry.npmjs.org/express/-/express-4.16.3.tgz",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.16.3.tgz",
       "integrity": "sha1-avilAjUNsyRuzEvs9rWjTSL37VM=",
       "dev": true,
       "requires": {
@@ -3693,14 +3692,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3715,20 +3712,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3845,8 +3839,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3858,7 +3851,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3873,7 +3865,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3881,14 +3872,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -3907,7 +3896,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3988,8 +3976,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4001,7 +3988,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4123,7 +4109,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4755,7 +4740,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -6064,9 +6049,8 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "dev": true,
       "requires": {
         "minimist": "0.0.8"
       },
@@ -6074,8 +6058,7 @@
         "minimist": {
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         }
       }
     },
@@ -9817,7 +9800,7 @@
       "dependencies": {
         "minimist": {
           "version": "0.0.10",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
           "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
           "dev": true
         }
@@ -11265,7 +11248,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,9 @@
     "node": ">=6"
   },
   "dependencies": {
+    "cpr": "^3.0.1",
     "debug": "^3.0.0",
+    "denodeify": "^1.2.1",
     "execa": "^1.0.0",
     "git-diff-apply": "^0.10.0",
     "inquirer": "^6.1.0",
@@ -43,6 +45,7 @@
     "npx": "^10.0.1",
     "opn": "^5.3.0",
     "semver": "^5.4.1",
+    "tmp": "0.0.33",
     "update-notifier": "^2.5.0",
     "yargs": "^12.0.0"
   },
@@ -50,7 +53,6 @@
     "chai": "^4.1.0",
     "cpr": "^3.0.1",
     "cross-env": "^5.0.1",
-    "denodeify": "^1.2.1",
     "ember-cli": "3.4.1",
     "ember-cli-addon-tests": "^0.11.0",
     "eslint": "^5.0.0",
@@ -62,8 +64,7 @@
     "git-fixtures": "^0.12.0",
     "mocha": "^5.0.0",
     "renovate-config-standard": "^1.0.0",
-    "sinon": "^6.0.0",
-    "tmp": "0.0.33"
+    "sinon": "^6.0.0"
   },
   "ember-addon": {
     "main": "src/ember-addon.js"

--- a/src/args.js
+++ b/src/args.js
@@ -37,5 +37,10 @@ module.exports = {
     type: 'boolean',
     default: false,
     description: 'List available codemods'
+  },
+  'create-custom-diff': {
+    type: 'boolean',
+    default: false,
+    description: 'Create a personal diff instead of using an output repo'
   }
 };

--- a/src/command.js
+++ b/src/command.js
@@ -55,6 +55,12 @@ module.exports = {
       description: args['list-codemods'].description,
       type: Boolean,
       default: args['list-codemods'].default
+    },
+    {
+      name: 'create-custom-diff',
+      description: args['create-custom-diff'].description,
+      type: Boolean,
+      default: args['create-custom-diff'].default
     }
   ],
 

--- a/src/get-start-and-end-commands.js
+++ b/src/get-start-and-end-commands.js
@@ -1,0 +1,52 @@
+'use strict';
+
+const path = require('path');
+const npx = require('./npx');
+const denodeify = require('denodeify');
+const tmpDir = denodeify(require('tmp').dir);
+const cpr = path.resolve(path.dirname(require.resolve('cpr')), '../bin/cpr');
+
+module.exports = function getStartAndEndCommands({
+  projectType,
+  startVersion,
+  endVersion
+}) {
+  let projectName;
+  let command;
+  switch (projectType) {
+    case 'app':
+      projectName = 'my-app';
+      command = `new ${projectName}`;
+      break;
+    case 'addon':
+      projectName = 'my-addon';
+      command = `addon ${projectName}`;
+      break;
+    case 'glimmer':
+      // projectName = 'my-app';
+      // command = `new ${projectName} -b @glimmer/blueprint`;
+      // break;
+      throw 'cannot checkout older versions of glimmer blueprint';
+  }
+
+  function createCommand(version) {
+    return tmpDir().then(cwd => {
+      return npx(`-p ember-cli@${version} ember ${command} -sn -sg`, { cwd }).then(() => {
+        return path.resolve(cwd, projectName);
+      });
+    }).then(appPath => {
+      return `node ${cpr} ${appPath} .`;
+    });
+  }
+
+  return Promise.all([
+    createCommand(startVersion),
+    createCommand(endVersion)
+  ]).then(([
+    startCommand,
+    endCommand
+  ]) => ({
+    startCommand,
+    endCommand
+  }));
+};

--- a/src/npx.js
+++ b/src/npx.js
@@ -4,10 +4,10 @@ const path = require('path');
 const execa = require('execa');
 const debug = require('debug')('ember-cli-update');
 
-module.exports = function npx(command) {
+module.exports = function npx(command, options = {}) {
   debug(`npx ${command}`);
-  return execa('npx', command.split(' '), {
+  return execa('npx', command.split(' '), Object.assign({}, {
     localDir: path.join(__dirname, '..'),
     stdio: 'inherit'
-  });
+  }, options));
 };

--- a/test/acceptance/ember-cli-update-test.js
+++ b/test/acceptance/ember-cli-update-test.js
@@ -32,7 +32,8 @@ describe('Acceptance - ember-cli-update', function() {
   function merge({
     fixturesPath,
     runCodemods,
-    subDir = ''
+    subDir = '',
+    createCustomDiff
   }) {
     buildTmp({
       fixturesPath,
@@ -52,6 +53,9 @@ describe('Acceptance - ember-cli-update', function() {
       args = [
         '--run-codemods'
       ];
+    }
+    if (createCustomDiff) {
+      args.push('--create-custom-diff');
     }
 
     return processBin({
@@ -148,6 +152,24 @@ describe('Acceptance - ember-cli-update', function() {
     return merge({
       fixturesPath: 'test/fixtures/local/my-app',
       subDir: 'foo/bar'
+    }).promise.then(({
+      status
+    }) => {
+      fixtureCompare({
+        mergeFixtures: 'test/fixtures/merge/my-app'
+      });
+
+      assertNormalUpdate(status);
+      assertNoUnstaged(status);
+    });
+  });
+
+  it('can create a personal diff instead of using an output repo', function() {
+    this.timeout(2 * 60 * 1000);
+
+    return merge({
+      fixturesPath: 'test/fixtures/local/my-app',
+      createCustomDiff: true
     }).promise.then(({
       status
     }) => {

--- a/test/unit/get-start-and-end-commands-test.js
+++ b/test/unit/get-start-and-end-commands-test.js
@@ -1,0 +1,12 @@
+'use strict';
+
+const { expect } = require('chai');
+const getStartAndEndCommands = require('../../src/get-start-and-end-commands');
+
+describe('Unit - getStartAndEndCommands', function() {
+  it('throws for glimmer apps', function() {
+    expect(() => getStartAndEndCommands({
+      projectType: 'glimmer'
+    })).to.throw('cannot checkout older versions of glimmer blueprint');
+  });
+});


### PR DESCRIPTION
Closes #125

Use your own versions of apps instead of the output repo's. The intent is to mix with your own .ember-cli file to get your own catered diffs. This is much slower (and more error-prone if it is a really old version) than the normal way to update.

```
ember-cli-update --custom-remote
```

@rwjblue @rwwagner90 @Turbo87 does this solve your yarn issues?