### PR TITLE
Support Detection of Ember/Glimmer apps as dependencies

### DIFF
--- a/src/get-project-options.js
+++ b/src/get-project-options.js
@@ -2,6 +2,7 @@
 
 module.exports = function getProjectOptions({
   keywords,
+  dependencies,
   devDependencies
 }) {
   let isAddon = keywords && keywords.indexOf('ember-addon') !== -1;
@@ -10,14 +11,16 @@ module.exports = function getProjectOptions({
     return ['addon'];
   }
 
-  if (devDependencies) {
-    let isGlimmer = devDependencies['@glimmer/blueprint'];
+  if (dependencies || devDependencies) {
+    let allDeps = Object.assign({}, dependencies, devDependencies);
+
+    let isGlimmer = allDeps['@glimmer/blueprint'];
 
     if (isGlimmer) {
       return ['glimmer'];
     }
 
-    let isApp = devDependencies['ember-cli'];
+    let isApp = allDeps['ember-cli'];
 
     if (isApp) {
       return ['app'];

--- a/src/get-project-options.js
+++ b/src/get-project-options.js
@@ -11,20 +11,18 @@ module.exports = function getProjectOptions({
     return ['addon'];
   }
 
-  if (dependencies || devDependencies) {
-    let allDeps = Object.assign({}, dependencies, devDependencies);
+  let allDeps = Object.assign({}, dependencies, devDependencies);
 
-    let isGlimmer = allDeps['@glimmer/blueprint'];
+  let isGlimmer = allDeps['@glimmer/blueprint'];
 
-    if (isGlimmer) {
-      return ['glimmer'];
-    }
+  if (isGlimmer) {
+    return ['glimmer'];
+  }
 
-    let isApp = allDeps['ember-cli'];
+  let isApp = allDeps['ember-cli'];
 
-    if (isApp) {
-      return ['app'];
-    }
+  if (isApp) {
+    return ['app'];
   }
 
   throw 'Ember CLI project type could not be determined';

--- a/test/unit/get-project-options-test.js
+++ b/test/unit/get-project-options-test.js
@@ -13,7 +13,7 @@ describe(getProjectOptions, function() {
     }).to.throw('Ember CLI project type could not be determined');
   });
 
-  it('detects ember app', function() {
+  it('detects ember app with ember-cli as a devDependency', function() {
     let packageJson = {
       devDependencies: {
         'ember-cli': '2.11'
@@ -23,7 +23,17 @@ describe(getProjectOptions, function() {
     expect(getProjectOptions(packageJson)).to.deep.equal(['app']);
   });
 
-  it('detects ember addon', function() {
+  it('detects ember app with ember-cli as a dependency', function() {
+    let packageJson = {
+      dependencies: {
+        'ember-cli': '2.11'
+      }
+    };
+
+    expect(getProjectOptions(packageJson)).to.deep.equal(['app']);
+  });
+
+  it('detects ember addon with ember-cli as a devDependency', function() {
     let packageJson = {
       keywords: [
         'ember-addon'
@@ -36,9 +46,32 @@ describe(getProjectOptions, function() {
     expect(getProjectOptions(packageJson)).to.deep.equal(['addon']);
   });
 
-  it('detects glimmer app', function() {
+  it('detects ember addon with ember-cli as a dependency', function() {
+    let packageJson = {
+      keywords: [
+        'ember-addon'
+      ],
+      dependencies: {
+        'ember-cli': '2.11'
+      }
+    };
+
+    expect(getProjectOptions(packageJson)).to.deep.equal(['addon']);
+  });
+
+  it('detects glimmer app with glimmer as a devDependency', function() {
     let packageJson = {
       devDependencies: {
+        '@glimmer/blueprint': '0.3'
+      }
+    };
+
+    expect(getProjectOptions(packageJson)).to.deep.equal(['glimmer']);
+  });
+
+  it('detects glimmer app with glimmer as a dependency', function() {
+    let packageJson = {
+      dependencies: {
         '@glimmer/blueprint': '0.3'
       }
     };


### PR DESCRIPTION
This change allows ember-cli/glimmer to be specified as either a dependency
or devDependency of the project being updated. Currently, `ember-cli-update`
throws an error in some instances, since it is only checking devDependencies.