### PR TITLE
Get package version if dependency

### DIFF
--- a/src/get-package-version.js
+++ b/src/get-package-version.js
@@ -1,13 +1,12 @@
 'use strict';
 
 module.exports = function getPackageVersion({
+  dependencies,
   devDependencies
 }, packageName) {
-  let packageVersion;
+  let allDeps = Object.assign({}, dependencies, devDependencies);
 
-  if (devDependencies) {
-    packageVersion = devDependencies[packageName];
-  }
+  let packageVersion = allDeps[packageName];
 
   if (!packageVersion) {
     throw 'Ember CLI blueprint version could not be determined';

--- a/test/unit/get-package-version-test.js
+++ b/test/unit/get-package-version-test.js
@@ -23,7 +23,16 @@ describe(getPackageVersion, function() {
     }).to.throw('Ember CLI blueprint version could not be determined');
   });
 
-  it('gets version', function() {
+  it('gets version as dependency', function() {
+    let packageJson = {
+      dependencies: {
+        'test-package-name': '2.11'
+      }
+    };
+
+    expect(getPackageVersion(packageJson, 'test-package-name')).to.equal('2.11');
+  });
+  it('gets version as devDependency', function() {
     let packageJson = {
       devDependencies: {
         'test-package-name': '2.11'


### PR DESCRIPTION
Currently we only check `devDependencies`, so if the requested package is in `dependencies`, an error is thrown. We should be able to find it regardless.