### PR TITLE
support custom blueprints

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ ember-cli-update --run-codemods
 
 | Option | Description | Type | Examples | Default |
 |---|---|---|---|---|
+| --blueprint | Provide a custom blueprint for use in the update | String | "@glimmer/blueprint" "git+https://git@github.com/tildeio/libkit.git" "../blueprint" | |
 | --from | Use a starting version that is different than what is in your package.json | String | "2.9.1" | |
 | --to | Update to a version that isn\'t latest | String | "2.14.1" "~2.15" "latest" "beta" | "latest" |
 | --resolve-conflicts | Automatically run git mergetool if conflicts found | Boolean | | false |

--- a/bin/ember-cli-update.js
+++ b/bin/ember-cli-update.js
@@ -7,6 +7,7 @@ const args = require('../src/args');
 const { argv } = require('yargs')
   .options(args);
 
+const blueprint = argv['blueprint'];
 const from = argv['from'];
 const to = argv['to'];
 const resolveConflicts = argv['resolve-conflicts'];
@@ -35,6 +36,7 @@ updateNotifier({
 (async() => {
   try {
     let message = await emberCliUpdate({
+      blueprint,
       from,
       to,
       resolveConflicts,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1962,6 +1962,12 @@
         "check-error": "^1.0.2"
       }
     },
+    "chai-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/chai-string/-/chai-string-1.5.0.tgz",
+      "integrity": "sha512-sydDC3S3pNAQMYwJrs6dQX0oBQ6KfIPuOZ78n7rocW0eJJlsHPh2t3kwW7xfwYA/1Bf6/arGtSUo16rxR2JFlw==",
+      "dev": true
+    },
     "chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "fs-extra": "^8.0.0",
     "resolve": "^1.10.0",
     "semver": "^6.0.0",
+    "tmp": "0.1.0",
     "update-notifier": "^3.0.0",
     "which": "^1.3.1",
     "yargs": "^13.0.0"
@@ -52,6 +53,7 @@
   "devDependencies": {
     "chai": "^4.1.0",
     "chai-as-promised": "^7.1.1",
+    "chai-string": "^1.5.0",
     "cpr": "^3.0.1",
     "cross-env": "^5.0.1",
     "ember-cli": "3.11.0",

--- a/src/args.js
+++ b/src/args.js
@@ -1,4 +1,9 @@
 module.exports = {
+  'blueprint': {
+    alias: ['b'],
+    type: 'string',
+    description: 'Provide a custom blueprint for use in the update'
+  },
   'from': {
     type: 'string',
     description: 'Use a starting version that is different than what is in your package.json ("2.9.1")'

--- a/src/command.js
+++ b/src/command.js
@@ -10,6 +10,12 @@ module.exports = {
 
   availableOptions: [
     {
+      name: 'blueprint',
+      aliases: args['blueprint'].alias,
+      description: args['blueprint'].description,
+      type: String
+    },
+    {
       name: 'from',
       description: args['from'].description,
       type: String

--- a/src/download-blueprint.js
+++ b/src/download-blueprint.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const path = require('path');
+const { promisify } = require('util');
+const tmpDir = promisify(require('tmp').dir);
+const run = require('./run');
+
+async function downloadBlueprint(name, url, range) {
+  if (url) {
+    url += `#semver:${range}`;
+  } else {
+    url = `${name}@${range}`;
+  }
+  let newTmpDir = await tmpDir();
+  let output = await run(`npm install ${url}`, { cwd: newTmpDir });
+  if (!name) {
+    name = output.match(/^\+ (.*)@\d\.\d\.\d.*$/m)[1];
+  }
+  let _path = path.join(newTmpDir, 'node_modules', name);
+  return {
+    name,
+    path: _path
+  };
+}
+
+module.exports = downloadBlueprint;

--- a/src/get-project-options.js
+++ b/src/get-project-options.js
@@ -29,7 +29,11 @@ module.exports = async function getProjectOptions({
   keywords,
   dependencies,
   devDependencies
-}) {
+}, blueprint) {
+  if (blueprint) {
+    return ['blueprint'];
+  }
+
   let allDeps = Object.assign({}, dependencies, devDependencies);
 
   function checkForDep(packageName) {

--- a/src/get-tag-version.js
+++ b/src/get-tag-version.js
@@ -1,9 +1,18 @@
 'use strict';
 
+const path = require('path');
 const _getTagVersion = require('boilerplate-update/src/get-tag-version');
+const utils = require('./utils');
 
-module.exports = function getTagVersion(versions, packageName) {
+module.exports = function getTagVersion(versions, packageName, blueprintUrl) {
   return async function getTagVersion(range) {
+    if (blueprintUrl) {
+      let blueprint = await utils.downloadBlueprint(packageName, blueprintUrl, range);
+      // let result = await run('npm version', { cwd: blueprint.path });
+      // return eval(`(${result})`)[blueprint.name];
+      return require(path.join(blueprint.path, 'package')).version;
+    }
+
     return await _getTagVersion({
       range,
       versions,

--- a/src/parse-blueprint.js
+++ b/src/parse-blueprint.js
@@ -1,0 +1,40 @@
+'use strict';
+
+const path = require('path');
+let { URL } = require('url');
+const fs = require('fs-extra');
+
+function toPosixAbsolutePath(path) {
+  let posixPath = path.replace(/\\/g, '/').replace(/^(.+):/, function() {
+    return arguments[1].toLowerCase();
+  });
+  if (!posixPath.startsWith('/')) {
+    posixPath = `/${posixPath}`;
+  }
+  return posixPath;
+}
+
+async function parseBlueprint(blueprint) {
+  let name;
+  let url;
+  let blueprintPath = path.resolve(process.cwd(), blueprint);
+  if (await fs.pathExists(blueprintPath)) {
+    let posixBlueprintPath = toPosixAbsolutePath(blueprintPath);
+    url = `git+file://${posixBlueprintPath}`;
+  } else {
+    try {
+      // This matches Window's paths, so it can't be done first.
+      new URL(blueprint);
+      url = blueprint;
+    } catch (err) {
+      name = blueprint;
+    }
+  }
+  return {
+    name,
+    url
+  };
+}
+
+module.exports = parseBlueprint;
+module.exports.toPosixAbsolutePath = toPosixAbsolutePath;

--- a/src/run.js
+++ b/src/run.js
@@ -1,0 +1,12 @@
+'use strict';
+
+const { promisify } = require('util');
+const exec = promisify(require('child_process').exec);
+const debug = require('debug')('ember-cli-update');
+
+module.exports = async function run(command, options) {
+  debug(command);
+  let { stdout } = await exec(command, options);
+  debug(stdout);
+  return stdout;
+};

--- a/src/utils.js
+++ b/src/utils.js
@@ -10,3 +10,5 @@ module.exports.spawn = async function spawn() {
     ps.on('exit', resolve);
   });
 };
+
+module.exports.downloadBlueprint = require('./download-blueprint');

--- a/test/fixtures/local-blueprint-app/local/my-app/ember-cli-update.json
+++ b/test/fixtures/local-blueprint-app/local/my-app/ember-cli-update.json
@@ -1,0 +1,15 @@
+{
+  "blueprints": [
+    {
+      "name": "ember-cli-update-git-blueprint-test",
+      "location": "../local-blueprint",
+      "version": "0.0.1",
+      "isPartial": false
+    },
+    {
+      "name": "unused-partial-blueprint-test",
+      "version": "0.0.1",
+      "isPartial": true
+    }
+  ]
+}

--- a/test/fixtures/local-blueprint-app/local/my-app/package.json
+++ b/test/fixtures/local-blueprint-app/local/my-app/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "my-app",
+  "version": "0.0.0",
+  "description": "",
+  "main": "index.js"
+}

--- a/test/fixtures/local-blueprint-app/merge/my-app/ember-cli-update.json
+++ b/test/fixtures/local-blueprint-app/merge/my-app/ember-cli-update.json
@@ -1,0 +1,15 @@
+{
+  "blueprints": [
+    {
+      "name": "ember-cli-update-git-blueprint-test",
+      "location": "../local-blueprint",
+      "version": "0.0.2",
+      "isPartial": false
+    },
+    {
+      "name": "unused-partial-blueprint-test",
+      "version": "0.0.1",
+      "isPartial": true
+    }
+  ]
+}

--- a/test/fixtures/local-blueprint-app/merge/my-app/package.json
+++ b/test/fixtures/local-blueprint-app/merge/my-app/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "my-app",
+  "version": "0.0.0",
+  "description": "",
+  "main": "index.js"
+}

--- a/test/fixtures/local-blueprint/v0.0.1/blueprints/ember-cli-update-git-blueprint-test/index.js
+++ b/test/fixtures/local-blueprint/v0.0.1/blueprints/ember-cli-update-git-blueprint-test/index.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const path = require('path');
+const MainBlueprint = require('../../../index');
+
+/*
+  Create an "addon blueprint" that simply defers to our
+  top level entry point as the blueprint.
+
+  This is basically just a work around for
+  https://github.com/ember-cli/ember-cli/issues/6952.
+
+  Once that issue is fixed and released we can remove:
+
+    * ember-addon keyword in package.json
+    * ember-addon key in package.json
+    * ember-addon-main.js file
+    * blueprints/ folder
+ */
+module.exports = Object.assign({}, MainBlueprint, {
+  init() {
+    this._super.init.apply(this, arguments);
+
+    this.path = path.join(__dirname, '..', '..');
+    this.name = 'ember-cli-update-git-blueprint-test';
+  }
+});

--- a/test/fixtures/local-blueprint/v0.0.1/ember-addon-main.js
+++ b/test/fixtures/local-blueprint/v0.0.1/ember-addon-main.js
@@ -1,0 +1,19 @@
+'use strict';
+
+/*
+  Create an "addon blueprint" that simply defers to our
+  top level entry point as the blueprint.
+
+  This is basically just a work around for
+  https://github.com/ember-cli/ember-cli/issues/6952.
+
+  Once that issue is fixed and released we can remove:
+
+  * ember-addon keyword in package.json
+  * ember-addon key in package.json
+  * ember-addon-main.js file
+  * blueprints/ folder
+  */
+module.exports = {
+  name: 'ember-cli-update-git-blueprint-test'
+};

--- a/test/fixtures/local-blueprint/v0.0.1/files/ember-cli-update.json
+++ b/test/fixtures/local-blueprint/v0.0.1/files/ember-cli-update.json
@@ -1,0 +1,10 @@
+{
+  "blueprints": [
+    {
+      "name": "ember-cli-update-git-blueprint-test",
+      "location": "../local-blueprint",
+      "version": "<%= blueprintVersion %>",
+      "isPartial": false
+    }
+  ]
+}

--- a/test/fixtures/local-blueprint/v0.0.1/files/package.json
+++ b/test/fixtures/local-blueprint/v0.0.1/files/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "<%= name %>",
+  "version": "0.0.0",
+  "description": "",
+  "main": "index.js"
+}

--- a/test/fixtures/local-blueprint/v0.0.1/index.js
+++ b/test/fixtures/local-blueprint/v0.0.1/index.js
@@ -1,0 +1,15 @@
+'use strict';
+
+module.exports = {
+  description: 'ember-cli-update-git-blueprint-test',
+
+  locals(options) {
+    let name = options.entity.name;
+    let blueprintVersion = require('./package').version;
+
+    return {
+      name,
+      blueprintVersion
+    };
+  }
+};

--- a/test/fixtures/local-blueprint/v0.0.1/package.json
+++ b/test/fixtures/local-blueprint/v0.0.1/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "ember-cli-update-git-blueprint-test",
+  "version": "0.0.1",
+  "description": "",
+  "main": "index.js",
+  "keywords": [
+    "ember-addon"
+  ],
+  "ember-addon": {
+    "main": "ember-addon-main.js"
+  }
+}

--- a/test/fixtures/local-blueprint/v0.0.2/blueprints/ember-cli-update-git-blueprint-test/index.js
+++ b/test/fixtures/local-blueprint/v0.0.2/blueprints/ember-cli-update-git-blueprint-test/index.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const path = require('path');
+const MainBlueprint = require('../../../index');
+
+/*
+  Create an "addon blueprint" that simply defers to our
+  top level entry point as the blueprint.
+
+  This is basically just a work around for
+  https://github.com/ember-cli/ember-cli/issues/6952.
+
+  Once that issue is fixed and released we can remove:
+
+    * ember-addon keyword in package.json
+    * ember-addon key in package.json
+    * ember-addon-main.js file
+    * blueprints/ folder
+ */
+module.exports = Object.assign({}, MainBlueprint, {
+  init() {
+    this._super.init.apply(this, arguments);
+
+    this.path = path.join(__dirname, '..', '..');
+    this.name = 'ember-cli-update-git-blueprint-test';
+  }
+});

--- a/test/fixtures/local-blueprint/v0.0.2/ember-addon-main.js
+++ b/test/fixtures/local-blueprint/v0.0.2/ember-addon-main.js
@@ -1,0 +1,19 @@
+'use strict';
+
+/*
+  Create an "addon blueprint" that simply defers to our
+  top level entry point as the blueprint.
+
+  This is basically just a work around for
+  https://github.com/ember-cli/ember-cli/issues/6952.
+
+  Once that issue is fixed and released we can remove:
+
+  * ember-addon keyword in package.json
+  * ember-addon key in package.json
+  * ember-addon-main.js file
+  * blueprints/ folder
+  */
+module.exports = {
+  name: 'ember-cli-update-git-blueprint-test'
+};

--- a/test/fixtures/local-blueprint/v0.0.2/files/ember-cli-update.json
+++ b/test/fixtures/local-blueprint/v0.0.2/files/ember-cli-update.json
@@ -1,0 +1,10 @@
+{
+  "blueprints": [
+    {
+      "name": "ember-cli-update-git-blueprint-test",
+      "location": "../local-blueprint",
+      "version": "<%= blueprintVersion %>",
+      "isPartial": false
+    }
+  ]
+}

--- a/test/fixtures/local-blueprint/v0.0.2/files/package.json
+++ b/test/fixtures/local-blueprint/v0.0.2/files/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "<%= name %>",
+  "version": "0.0.0",
+  "description": "",
+  "main": "index.js"
+}

--- a/test/fixtures/local-blueprint/v0.0.2/index.js
+++ b/test/fixtures/local-blueprint/v0.0.2/index.js
@@ -1,0 +1,15 @@
+'use strict';
+
+module.exports = {
+  description: 'ember-cli-update-git-blueprint-test',
+
+  locals(options) {
+    let name = options.entity.name;
+    let blueprintVersion = require('./package').version;
+
+    return {
+      name,
+      blueprintVersion
+    };
+  }
+};

--- a/test/fixtures/local-blueprint/v0.0.2/package.json
+++ b/test/fixtures/local-blueprint/v0.0.2/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "ember-cli-update-git-blueprint-test",
+  "version": "0.0.2",
+  "description": "",
+  "main": "index.js",
+  "keywords": [
+    "ember-addon"
+  ],
+  "ember-addon": {
+    "main": "ember-addon-main.js"
+  }
+}

--- a/test/fixtures/npm-blueprint-app/local/my-app/ember-cli-update.json
+++ b/test/fixtures/npm-blueprint-app/local/my-app/ember-cli-update.json
@@ -1,0 +1,8 @@
+{
+  "blueprints": [
+    {
+      "name": "ember-cli-update-npm-blueprint-test",
+      "version": "0.0.5"
+    }
+  ]
+}

--- a/test/fixtures/npm-blueprint-app/local/my-app/package.json
+++ b/test/fixtures/npm-blueprint-app/local/my-app/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "my-app",
+  "version": "0.0.0",
+  "description": "",
+  "main": "index.js"
+}

--- a/test/fixtures/npm-blueprint-app/merge/my-app/ember-cli-update.json
+++ b/test/fixtures/npm-blueprint-app/merge/my-app/ember-cli-update.json
@@ -1,0 +1,8 @@
+{
+  "blueprints": [
+    {
+      "name": "ember-cli-update-npm-blueprint-test",
+      "version": "0.0.6"
+    }
+  ]
+}

--- a/test/fixtures/npm-blueprint-app/merge/my-app/package.json
+++ b/test/fixtures/npm-blueprint-app/merge/my-app/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "my-app",
+  "version": "0.0.0",
+  "description": "",
+  "main": "index.js"
+}

--- a/test/fixtures/remote-blueprint-app/local/my-app/ember-cli-update.json
+++ b/test/fixtures/remote-blueprint-app/local/my-app/ember-cli-update.json
@@ -1,0 +1,9 @@
+{
+  "blueprints": [
+    {
+      "name": "ember-cli-update-git-blueprint-test",
+      "location": "git+https://git@github.com/kellyselden/ember-cli-update-git-blueprint-test.git",
+      "version": "0.0.15"
+    }
+  ]
+}

--- a/test/fixtures/remote-blueprint-app/local/my-app/package.json
+++ b/test/fixtures/remote-blueprint-app/local/my-app/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "my-app",
+  "version": "0.0.0",
+  "description": "",
+  "main": "index.js"
+}

--- a/test/fixtures/remote-blueprint-app/merge/my-app/ember-cli-update.json
+++ b/test/fixtures/remote-blueprint-app/merge/my-app/ember-cli-update.json
@@ -1,0 +1,9 @@
+{
+  "blueprints": [
+    {
+      "name": "ember-cli-update-git-blueprint-test",
+      "location": "git+https://git@github.com/kellyselden/ember-cli-update-git-blueprint-test.git",
+      "version": "0.0.16"
+    }
+  ]
+}

--- a/test/fixtures/remote-blueprint-app/merge/my-app/package.json
+++ b/test/fixtures/remote-blueprint-app/merge/my-app/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "my-app",
+  "version": "0.0.0",
+  "description": "",
+  "main": "index.js"
+}

--- a/test/helpers/blueprint.js
+++ b/test/helpers/blueprint.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const path = require('path');
+const fs = require('fs-extra');
+const { buildTmp } = require('git-fixtures');
+
+async function initBlueprint(fixturesPath, location) {
+  let blueprintPath = await buildTmp({
+    fixturesPath
+  });
+
+  let newBlueprintPath = path.resolve(blueprintPath, location);
+
+  await fs.remove(newBlueprintPath);
+
+  await fs.move(blueprintPath, newBlueprintPath);
+
+  return newBlueprintPath;
+}
+
+module.exports.initBlueprint = initBlueprint;

--- a/test/helpers/chai.js
+++ b/test/helpers/chai.js
@@ -3,6 +3,7 @@
 const chai = require('chai');
 
 chai.use(require('chai-as-promised'));
+chai.use(require('chai-string'));
 chai.use(require('sinon-chai'));
 
 module.exports = chai;

--- a/test/integration/download-blueprint-test.js
+++ b/test/integration/download-blueprint-test.js
@@ -1,0 +1,58 @@
+'use strict';
+
+const { describe, it } = require('../helpers/mocha');
+const { expect } = require('../helpers/chai');
+const path = require('path');
+const { tmpdir } = require('os');
+const { initBlueprint } = require('../helpers/blueprint');
+const parseBlueprint = require('../../src/parse-blueprint');
+const downloadBlueprint = require('../../src/download-blueprint');
+
+describe(downloadBlueprint, function() {
+  this.timeout(10 * 1000);
+
+  it('downloads local paths as urls', async function() {
+    let {
+      name,
+      location,
+      version: range
+    } = require('../fixtures/local-blueprint-app/local/my-app/ember-cli-update').blueprints[0];
+
+    let blueprintPath = await initBlueprint('test/fixtures/local-blueprint', location);
+
+    let { url } = await parseBlueprint(blueprintPath);
+
+    let blueprint = await downloadBlueprint(null, url, range);
+
+    expect(blueprint.name).to.equal(name);
+    expect(blueprint.path).to.startWith(tmpdir()).and.endWith(path.join('node_modules', name));
+    expect(require(path.join(blueprint.path, 'package')).version).to.equal(range);
+  });
+
+  it('downloads urls', async function() {
+    let {
+      name,
+      location: url,
+      version: range
+    } = require('../fixtures/remote-blueprint-app/local/my-app/ember-cli-update').blueprints[0];
+
+    let blueprint = await downloadBlueprint(null, url, range);
+
+    expect(blueprint.name).to.equal(name);
+    expect(blueprint.path).to.startWith(tmpdir()).and.endWith(path.join('node_modules', name));
+    expect(require(path.join(blueprint.path, 'package')).version).to.equal(range);
+  });
+
+  it('downloads npm packages', async function() {
+    let {
+      name,
+      version: range
+    } = require('../fixtures/npm-blueprint-app/local/my-app/ember-cli-update').blueprints[0];
+
+    let blueprint = await downloadBlueprint(name, null, range);
+
+    expect(blueprint.name).to.equal(name);
+    expect(blueprint.path).to.startWith(tmpdir()).and.endWith(path.join('node_modules', name));
+    expect(require(path.join(blueprint.path, 'package')).version).to.equal(range);
+  });
+});

--- a/test/integration/get-tag-version-test.js
+++ b/test/integration/get-tag-version-test.js
@@ -1,0 +1,57 @@
+'use strict';
+
+const { describe, it } = require('../helpers/mocha');
+const { expect } = require('../helpers/chai');
+const path = require('path');
+const sinon = require('sinon');
+const utils = require('../../src/utils');
+const _getTagVersion = require('../../src/get-tag-version');
+
+describe(_getTagVersion, function() {
+  let sandbox;
+  let downloadBlueprintStub;
+
+  beforeEach(function() {
+    sandbox = sinon.createSandbox();
+
+    downloadBlueprintStub = sandbox.stub(utils, 'downloadBlueprint');
+  });
+
+  afterEach(function() {
+    sandbox.restore();
+  });
+
+  it('uses local semver', async function() {
+    let version = '0.0.1';
+    let range = '*';
+
+    let getTagVersion = _getTagVersion([version], null, null);
+
+    let _version = await getTagVersion(range);
+
+    expect(_version).to.equal(version);
+
+    expect(downloadBlueprintStub).to.not.be.called;
+  });
+
+  it('downloads blueprint', async function() {
+    let {
+      name,
+      location,
+      version
+    } = require('../fixtures/local-blueprint-app/local/my-app/ember-cli-update').blueprints[0];
+    let range = '*';
+
+    let getTagVersion = _getTagVersion(null, name, location);
+
+    let blueprint = { path: path.resolve(`test/fixtures/local-blueprint/v${version}`) };
+
+    downloadBlueprintStub.withArgs(name, location, range).resolves(blueprint);
+
+    let _version = await getTagVersion(range);
+
+    expect(_version).to.equal(version);
+
+    expect(downloadBlueprintStub).to.be.calledOnce;
+  });
+});

--- a/test/integration/parse-blueprint-test.js
+++ b/test/integration/parse-blueprint-test.js
@@ -1,0 +1,63 @@
+'use strict';
+
+const { describe, it } = require('../helpers/mocha');
+const { expect } = require('../helpers/chai');
+const path = require('path');
+const parseBlueprint = require('../../src/parse-blueprint');
+
+const { toPosixAbsolutePath } = parseBlueprint;
+
+describe(parseBlueprint, function() {
+  it('detects local paths', async function() {
+    let blueprint = 'test/fixtures/local-blueprint';
+
+    let parsedBlueprint = await parseBlueprint(blueprint);
+
+    expect(parsedBlueprint).to.deep.equal({
+      name: undefined,
+      url: `git+file://${toPosixAbsolutePath(path.join(process.cwd(), blueprint))}`
+    });
+  });
+
+  it('detects urls', async function() {
+    let blueprint = 'http://test-blueprint.com';
+
+    let parsedBlueprint = await parseBlueprint(blueprint);
+
+    expect(parsedBlueprint).to.deep.equal({
+      name: undefined,
+      url: blueprint
+    });
+  });
+
+  it('detects npm packages', async function() {
+    let blueprint = 'test-blueprint';
+
+    let parsedBlueprint = await parseBlueprint(blueprint);
+
+    expect(parsedBlueprint).to.deep.equal({
+      name: 'test-blueprint',
+      url: undefined
+    });
+  });
+
+  describe(toPosixAbsolutePath, function() {
+    it('does Windows', function() {
+      let before = 'C:\\foo\\bar';
+      let expected = '/c/foo/bar';
+
+      let actual = toPosixAbsolutePath(before);
+
+      expect(actual).to.equal(expected);
+    });
+
+    it('does Unix', function() {
+      let before = '/foo/bar';
+      let expected = '/foo/bar';
+
+      let actual = toPosixAbsolutePath(before);
+
+      expect(actual).to.equal(expected);
+    });
+  });
+});

--- a/test/unit/get-project-options-test.js
+++ b/test/unit/get-project-options-test.js
@@ -8,6 +8,7 @@ const _getProjectOptions = require('../../src/get-project-options');
 describe(_getProjectOptions, function() {
   let cwd;
   let packageJson;
+  let blueprint;
 
   before(function() {
     cwd = process.cwd();
@@ -15,6 +16,8 @@ describe(_getProjectOptions, function() {
 
   beforeEach(function() {
     packageJson = {};
+
+    blueprint = null;
   });
 
   afterEach(function() {
@@ -22,7 +25,7 @@ describe(_getProjectOptions, function() {
   });
 
   function getProjectOptions() {
-    return _getProjectOptions(packageJson);
+    return _getProjectOptions(packageJson, blueprint);
   }
 
   it('throws if not found', async function() {
@@ -150,5 +153,11 @@ describe(_getProjectOptions, function() {
     process.chdir(path.resolve(__dirname, '../fixtures/options/yarn'));
 
     expect(await getProjectOptions()).to.deep.equal(['app', 'yarn']);
+  });
+
+  it('detects blueprint', async function() {
+    blueprint = 'test-blueprint';
+
+    expect(await getProjectOptions()).to.deep.equal(['blueprint']);
   });
 });


### PR DESCRIPTION
A new `--blueprint` option will allow supplying a custom blueprint, much like ember-cli's blueprint option. You keep various blueprint's in sync with this, like the libkit or octane blueprints.

Using this though, you must supply the `--from` option. It cannot detect it like the default ember-cli blueprint.