### PR TITLE
don't throw for cases of `"ember-cli": "",`

### DIFF
--- a/src/get-package-version.js
+++ b/src/get-package-version.js
@@ -8,7 +8,7 @@ module.exports = function getPackageVersion({
 
   let packageVersion = allDeps[packageName];
 
-  if (!packageVersion) {
+  if (packageVersion === undefined) {
     throw 'Ember CLI blueprint version could not be determined';
   }
 

--- a/test/unit/get-package-version-test.js
+++ b/test/unit/get-package-version-test.js
@@ -32,6 +32,7 @@ describe(getPackageVersion, function() {
 
     expect(getPackageVersion(packageJson, 'test-package-name')).to.equal('2.11');
   });
+
   it('gets version as devDependency', function() {
     let packageJson = {
       devDependencies: {
@@ -40,5 +41,15 @@ describe(getPackageVersion, function() {
     };
 
     expect(getPackageVersion(packageJson, 'test-package-name')).to.equal('2.11');
+  });
+
+  it('doesn\'t throw if empty string', function() {
+    let packageJson = {
+      dependencies: {
+        'test-package-name': ''
+      }
+    };
+
+    expect(getPackageVersion(packageJson, 'test-package-name')).to.equal('');
   });
 });


### PR DESCRIPTION
which is valid semver