### PR TITLE
require local blueprints start with .

### DIFF
--- a/src/parse-blueprint-package.js
+++ b/src/parse-blueprint-package.js
@@ -14,12 +14,6 @@ function toPosixAbsolutePath(path) {
   return posixPath;
 }
 
-// https://stackoverflow.com/a/45242825/1703845
-function isSubDir(base, test) {
-  let relative = path.relative(base, test);
-  return !relative.startsWith('..') && !path.isAbsolute(relative);
-}
-
 async function parseBlueprintPackage({
   cwd = '.',
   blueprint
@@ -27,8 +21,15 @@ async function parseBlueprintPackage({
   let name;
   let location;
   let url;
-  let blueprintPath = path.resolve(cwd, blueprint);
-  if (await fs.pathExists(blueprintPath) && !isSubDir(cwd, blueprintPath)) {
+  let blueprintPath;
+
+  if (blueprint.startsWith('.')) {
+    blueprintPath = path.resolve(cwd, blueprint);
+  } else if (path.isAbsolute(blueprint) && await fs.pathExists(blueprint)) {
+    blueprintPath = blueprint;
+  }
+
+  if (blueprintPath) {
     let posixBlueprintPath = toPosixAbsolutePath(blueprintPath);
     url = `git+file://${posixBlueprintPath}`;
     location = blueprint;
@@ -42,6 +43,7 @@ async function parseBlueprintPackage({
       name = blueprint;
     }
   }
+
   return {
     name,
     location,

--- a/test/integration/parse-blueprint-package-test.js
+++ b/test/integration/parse-blueprint-package-test.js
@@ -23,21 +23,6 @@ describe(parseBlueprintPackage, function() {
     });
   });
 
-  it('ignores subdirs that collide with blueprint names', async function() {
-    let blueprint = 'config';
-
-    let parsedPackage = await parseBlueprintPackage({
-      cwd: path.resolve(__dirname, '../fixtures/blueprint/app/local-app/local/my-app'),
-      blueprint
-    });
-
-    expect(parsedPackage).to.deep.equal({
-      name: blueprint,
-      location: undefined,
-      url: undefined
-    });
-  });
-
   it('detects urls', async function() {
     let blueprint = 'http://test-blueprint.com';
 
@@ -56,6 +41,25 @@ describe(parseBlueprintPackage, function() {
     let blueprint = 'test-blueprint';
 
     let parsedPackage = await parseBlueprintPackage({
+      blueprint
+    });
+
+    expect(parsedPackage).to.deep.equal({
+      name: blueprint,
+      location: undefined,
+      url: undefined
+    });
+  });
+
+  it('uses npm even if subdir match', async function() {
+    let blueprint = 'config';
+
+    let cwd = path.resolve(__dirname, '../fixtures/blueprint/app/local-app/local/my-app');
+
+    expect(cwd).to.be.a.directory().and.include.subDirs([blueprint]);
+
+    let parsedPackage = await parseBlueprintPackage({
+      cwd,
       blueprint
     });
 


### PR DESCRIPTION
Previously we had logic to detect the difference between a subdir with the name "foo" and an npm package "foo". This prevented a self referencings blueprints "." because it would be considered a subdir. Now we avoid this problem by requiring local blueprints start with ".". So "foo" => "./foo".