### PR TITLE
use `e3` syntax in tests to mean seconds

### DIFF
--- a/test/acceptance/ember-addon-test.js
+++ b/test/acceptance/ember-addon-test.js
@@ -19,7 +19,7 @@ const loadSafeBlueprintFile = require('../../src/load-safe-blueprint-file');
 const saveBlueprintFile = require('../../src/save-blueprint-file');
 
 describe(function() {
-  this.timeout(60 * 1000);
+  this.timeout(60e3);
 
   let tmpPath;
 

--- a/test/acceptance/ember-cli-update-test.js
+++ b/test/acceptance/ember-cli-update-test.js
@@ -26,7 +26,7 @@ const down = '\u001b[B';
 const enter = '\n';
 
 describe(function() {
-  this.timeout(30 * 1000);
+  this.timeout(30e3);
 
   let tmpPath;
 
@@ -144,9 +144,9 @@ describe(function() {
 
   it('runs codemods', async function() {
     if (process.platform === 'darwin') {
-      this.timeout(1.5 * 60 * 1000);
+      this.timeout(1.5 * 60e3);
     } else {
-      this.timeout(60 * 1000);
+      this.timeout(60e3);
     }
 
     async function _merge(src, dest) {
@@ -387,7 +387,7 @@ describe(function() {
   });
 
   it('can install an addon with a default blueprint and a state file', async function() {
-    this.timeout((process.platform === 'darwin' ? 3 : 1) * 60 * 1000);
+    this.timeout((process.platform === 'darwin' ? 3 : 1) * 60e3);
 
     let {
       location
@@ -428,7 +428,7 @@ describe(function() {
   });
 
   it('can update a legacy addon blueprint', async function() {
-    this.timeout(5 * 60 * 1000);
+    this.timeout(5 * 60e3);
 
     let {
       name,
@@ -471,7 +471,7 @@ describe(function() {
   // in existing npm addons
   // https://github.com/salsify/ember-cli-dependency-lint/blob/v1.0.3/lib/commands/dependency-lint.js#L5
   it('can update a npm addon blueprint with implicit peer dep', async function() {
-    this.timeout(5 * 60 * 1000);
+    this.timeout(5 * 60e3);
 
     let {
       name,

--- a/test/integration/check-for-blueprint-updates-test.js
+++ b/test/integration/check-for-blueprint-updates-test.js
@@ -8,7 +8,7 @@ const loadSafeBlueprintFile = require('../../src/load-safe-blueprint-file');
 const { createTmpDir } = require('../../src/tmp');
 
 describe(checkForBlueprintUpdates, function() {
-  this.timeout(30 * 1000);
+  this.timeout(30e3);
 
   let tmpPath;
 

--- a/test/integration/codemods-test.js
+++ b/test/integration/codemods-test.js
@@ -13,7 +13,7 @@ const {
 } = require('../helpers/assertions');
 
 describe(codemods, function() {
-  this.timeout(30 * 1000);
+  this.timeout(30e3);
 
   let tmpPath;
 

--- a/test/integration/compare-test.js
+++ b/test/integration/compare-test.js
@@ -18,7 +18,7 @@ const sinon = require('sinon');
 const inquirer = require('inquirer');
 
 describe(compare, function() {
-  this.timeout(30 * 1000);
+  this.timeout(30e3);
 
   let tmpPath;
   let open;

--- a/test/integration/download-package-test.js
+++ b/test/integration/download-package-test.js
@@ -12,7 +12,7 @@ const { createTmpDir } = require('../../src/tmp');
 const fs = require('fs-extra');
 
 describe(downloadPackage, function() {
-  this.timeout(30 * 1000);
+  this.timeout(30e3);
 
   let tmpPath;
 

--- a/test/integration/index-test.js
+++ b/test/integration/index-test.js
@@ -26,7 +26,7 @@ const {
 const { EOL } = require('os');
 
 describe(function() {
-  this.timeout(30 * 1000);
+  this.timeout(30e3);
 
   let tmpPath;
 

--- a/test/integration/init-test.js
+++ b/test/integration/init-test.js
@@ -20,7 +20,7 @@ const {
 } = require('../../src/constants');
 
 describe(init, function() {
-  this.timeout(30 * 1000);
+  this.timeout(30e3);
 
   let tmpPath;
 

--- a/test/integration/install-test.js
+++ b/test/integration/install-test.js
@@ -18,7 +18,7 @@ const { initBlueprint } = require('../helpers/blueprint');
 const loadSafeBlueprintFile = require('../../src/load-safe-blueprint-file');
 
 describe(install, function() {
-  this.timeout(60 * 1000);
+  this.timeout(60e3);
 
   let tmpPath;
 

--- a/test/integration/overwrite-blueprint-files-test.js
+++ b/test/integration/overwrite-blueprint-files-test.js
@@ -13,7 +13,7 @@ const sinon = require('sinon');
 const { ember } = require('../../src/ember-install-addon');
 
 describe(overwriteBlueprintFiles, function() {
-  this.timeout(60 * 1000);
+  this.timeout(60e3);
 
   it('can install an addon with a default blueprint and no state file', async function() {
     let tmpPath = await buildTmp({

--- a/test/integration/reset-test.js
+++ b/test/integration/reset-test.js
@@ -18,7 +18,7 @@ const sinon = require('sinon');
 const inquirer = require('inquirer');
 
 describe(reset, function() {
-  this.timeout(30 * 1000);
+  this.timeout(30e3);
 
   let tmpPath;
 

--- a/test/integration/save-test.js
+++ b/test/integration/save-test.js
@@ -15,7 +15,7 @@ const {
 const loadSafeBlueprintFile = require('../../src/load-safe-blueprint-file');
 
 describe(save, function() {
-  this.timeout(5 * 1000);
+  this.timeout(5e3);
 
   let tmpPath;
 

--- a/test/integration/stats-test.js
+++ b/test/integration/stats-test.js
@@ -21,7 +21,7 @@ const {
 } = require('../../src/constants');
 
 describe(stats, function() {
-  this.timeout(30 * 1000);
+  this.timeout(30e3);
 
   let tmpPath;
 


### PR DESCRIPTION
I've been using this convention lately. `e3` is a more concise way to say seconds than `* 1000`.