### PR TITLE
Fix custom blueprints

### DIFF
--- a/src/get-start-and-end-commands.js
+++ b/src/get-start-and-end-commands.js
@@ -174,7 +174,7 @@ function runEmberRemotely({
   let isGlimmer = blueprint.packageName === glimmerPackageName && blueprint.name === glimmerPackageName;
 
   if (isCustomBlueprint || isGlimmer) {
-    args = [`ember-cli@${lastNode8Version}`, ...args];
+    args = ['ember-cli@latest', ...args];
     // args = ['-p', 'github:ember-cli/ember-cli#cfb9780', 'ember', 'new', projectName, `-dir=${directoryName}, '-sg', -sn', '-b', `${blueprint.packageName}@${blueprint.version}`];
   } else {
     args = ['-p', `ember-cli@${blueprint.version}`, 'ember', ...args];

--- a/src/get-start-and-end-commands.js
+++ b/src/get-start-and-end-commands.js
@@ -131,7 +131,6 @@ function getArgs({
   return [
     ...args,
     '-sn',
-    '-sb',
     '-b',
     _blueprint,
     ...blueprint.options

--- a/src/get-start-and-end-commands.js
+++ b/src/get-start-and-end-commands.js
@@ -109,7 +109,7 @@ function getArgs({
     args.push(`-dir=${directoryName}`);
   }
 
-  args.push('-sg');
+  args.push('--skip-git');
 
   let _blueprint;
   if (blueprint.path) {
@@ -130,7 +130,7 @@ function getArgs({
 
   return [
     ...args,
-    '-sn',
+    '--skip-npm',
     '-b',
     _blueprint,
     ...blueprint.options

--- a/test/unit/get-start-and-end-commands-test.js
+++ b/test/unit/get-start-and-end-commands-test.js
@@ -121,9 +121,8 @@ describe(_getStartAndEndCommands, function() {
         path.normalize(`${packageRoot}/bin/ember`),
         'new',
         projectName,
-        '-sg',
-        '-sn',
-        '-sb',
+        '--skip-git',
+        '--skip-npm',
         '-b',
         'app'
       ],
@@ -152,9 +151,8 @@ describe(_getStartAndEndCommands, function() {
         commandName,
         'new',
         projectName,
-        '-sg',
-        '-sn',
-        '-sb',
+        '--skip-git',
+        '--skip-npm',
         '-b',
         'app'
       ],
@@ -296,9 +294,8 @@ describe(_getStartAndEndCommands, function() {
           path.normalize(`${packageRoot}/bin/ember`),
           'new',
           projectName,
-          '-sg',
-          '-sn',
-          '-sb',
+          '--skip-git',
+          '--skip-npm',
           '-b',
           blueprintPath
         ],
@@ -335,12 +332,11 @@ describe(_getStartAndEndCommands, function() {
 
       expect(npxStub.args).to.deep.equal([[
         [
-          `${packageName}@3.16`,
+          `${packageName}@latest`,
           'new',
           projectName,
-          '-sg',
-          '-sn',
-          '-sb',
+          '--skip-git',
+          '--skip-npm',
           '-b',
           blueprintPath
         ],
@@ -385,9 +381,8 @@ describe(_getStartAndEndCommands, function() {
             path.normalize(`${packageRoot}/bin/ember`),
             'new',
             projectName,
-            '-sg',
-            '-sn',
-            '-sb',
+            '--skip-git',
+            '--skip-npm',
             '-b',
             baseBlueprint.name,
             ...baseBlueprint.options
@@ -441,9 +436,8 @@ describe(_getStartAndEndCommands, function() {
             commandName,
             'new',
             projectName,
-            '-sg',
-            '-sn',
-            '-sb',
+            '--skip-git',
+            '--skip-npm',
             '-b',
             baseBlueprint.name,
             ...baseBlueprint.options
@@ -498,9 +492,8 @@ describe(_getStartAndEndCommands, function() {
           commandName,
           'new',
           'my-project',
-          '-sg',
-          '-sn',
-          '-sb',
+          '--skip-git',
+          '--skip-npm',
           '-b',
           baseBlueprint.name,
           ...baseBlueprint.options
@@ -610,9 +603,8 @@ describe(_getStartAndEndCommands, function() {
       expect(args).to.deep.equal([
         'new',
         projectName,
-        '-sg',
-        '-sn',
-        '-sb',
+        '--skip-git',
+        '--skip-npm',
         '-b',
         'app'
       ]);
@@ -628,9 +620,8 @@ describe(_getStartAndEndCommands, function() {
       expect(args).to.deep.equal([
         'new',
         projectName,
-        '-sg',
-        '-sn',
-        '-sb',
+        '--skip-git',
+        '--skip-npm',
         '-b',
         'addon',
         '--no-welcome'
@@ -649,9 +640,8 @@ describe(_getStartAndEndCommands, function() {
         'new',
         `@my-scope/${projectName}`,
         `-dir=${projectName}`,
-        '-sg',
-        '-sn',
-        '-sb',
+        '--skip-git',
+        '--skip-npm',
         '-b',
         'app'
       ]);
@@ -669,9 +659,8 @@ describe(_getStartAndEndCommands, function() {
       expect(args).to.deep.equal([
         'new',
         projectName,
-        '-sg',
-        '-sn',
-        '-sb',
+        '--skip-git',
+        '--skip-npm',
         '-b',
         '/path/to/my-blueprint'
       ]);
@@ -693,9 +682,8 @@ describe(_getStartAndEndCommands, function() {
       expect(args).to.deep.equal([
         'new',
         projectName,
-        '-sg',
-        '-sn',
-        '-sb',
+        '--skip-git',
+        '--skip-npm',
         '-b',
         'app',
         '--my-option-1',


### PR DESCRIPTION
This fixes the use of ember-cli-update with the v2 addon blueprint https://github.com/embroider-build/addon-blueprint

I know there are a few tests to fix but it shows the main things that needed to change: 

- use latest ember-cli for custom blueprints because it was locking down to 3.16 before because of the `lastNode8Version`
- remove `-sb` which I'm assuming was `--skip-bower`

I'm going to get tests passing on this but I'm wondering if now is a good time to remove the `lastNode8Version` since it has the comment `// remove when node 8 is dropped` which has already happened 🤔 