### PR TITLE
Add support for upgrading across the "vite boundary" of ember-cli 6.8

### DIFF
--- a/src/check-for-blueprint-updates.js
+++ b/src/check-for-blueprint-updates.js
@@ -6,34 +6,44 @@ const getTagVersion = require('boilerplate-update/src/get-tag-version');
 const { defaultTo } = require('./constants');
 const utils = require('./utils');
 
+/**
+ *
+ * @param {Object} options
+ * @param {string} options.cwd
+ * @param {string} options.blueprintName
+ * @returns {Promise<string>}
+ */
+async function getLatestVersion({ cwd, blueprint }) {
+  if (blueprint.location) {
+    let parsedPackage = await parseBlueprintPackage({
+      cwd,
+      packageName: blueprint.location || blueprint.packageName
+    });
+
+    let downloadedPackage = await downloadPackage(
+      blueprint.packageName,
+      parsedPackage.url,
+      defaultTo
+    );
+
+    return downloadedPackage.version;
+  }
+
+  let versions = await utils.getVersions(blueprint.packageName);
+  let latestVersion = await getTagVersion({
+    range: defaultTo,
+    versions,
+    packageName: blueprint.packageName
+  });
+
+  return latestVersion;
+}
+
 async function checkForBlueprintUpdates({ cwd, blueprints }) {
   return await Promise.all(
     blueprints.map(async blueprint => {
       let currentVersion = blueprint.version;
-      let latestVersion;
-
-      if (!blueprint.location) {
-        let versions = await utils.getVersions(blueprint.packageName);
-
-        latestVersion = await getTagVersion({
-          range: defaultTo,
-          versions,
-          packageName: blueprint.packageName
-        });
-      } else {
-        let parsedPackage = await parseBlueprintPackage({
-          cwd,
-          packageName: blueprint.location || blueprint.packageName
-        });
-
-        let downloadedPackage = await downloadPackage(
-          blueprint.packageName,
-          parsedPackage.url,
-          defaultTo
-        );
-
-        latestVersion = downloadedPackage.version;
-      }
+      let latestVersion = await getLatestVersion({ cwd, blueprint });
 
       return {
         blueprint,

--- a/src/constants.js
+++ b/src/constants.js
@@ -6,4 +6,9 @@ module.exports.defaultAddonBlueprintName = 'addon';
 
 module.exports.glimmerPackageName = '@glimmer/blueprint';
 
+module.exports.defaultAppPackageName =
+  '@ember-tooling/classic-build-app-blueprint';
+module.exports.defaultAddonPackageName =
+  '@ember-tooling/classic-build-addon-blueprint';
+
 module.exports.defaultTo = '*';

--- a/src/get-base-blueprint.js
+++ b/src/get-base-blueprint.js
@@ -17,25 +17,29 @@ const isDefaultBlueprint = require('./is-default-blueprint');
  */
 async function getBaseBlueprint({ cwd, blueprints, blueprint }) {
   let baseBlueprint;
-
   let isCustomBlueprint = !isDefaultBlueprint(blueprint);
 
   if (isCustomBlueprint && !blueprint.isBaseBlueprint) {
     baseBlueprint = blueprints.find(b => b.isBaseBlueprint);
+
     if (baseBlueprint) {
       baseBlueprint = loadSafeBlueprint(baseBlueprint);
+
       let isCustomBlueprint = !isDefaultBlueprint(baseBlueprint);
+
       if (isCustomBlueprint) {
         if (baseBlueprint.location) {
           let parsedPackage = await parseBlueprintPackage({
             cwd,
             packageName: baseBlueprint.location
           });
+
           let downloadedPackage = await downloadPackage(
             baseBlueprint.packageName,
             parsedPackage.url,
             baseBlueprint.version
           );
+
           baseBlueprint.path = downloadedPackage.path;
         }
       }

--- a/src/get-project-options.js
+++ b/src/get-project-options.js
@@ -57,11 +57,8 @@ module.exports = async function getProjectOptions(
   }
 
   let projectType = getProjectType(checkForDep, keywords);
-
   let options = [projectType];
-
   let cwd = process.cwd();
-
   let isYarn = await hasYarn(cwd);
 
   if (isYarn) {

--- a/src/index.js
+++ b/src/index.js
@@ -112,11 +112,11 @@ module.exports = async function emberCliUpdate({
       );
       packageName = downloadedPackage.name;
     }
-    let blueprintName;
+
+    let blueprintName = packageName;
+
     if (blueprintArgs.blueprintName !== blueprintArgs.packageName) {
       blueprintName = blueprintArgs.blueprintName;
-    } else {
-      blueprintName = packageName;
     }
 
     let existingBlueprint = findBlueprint(
@@ -124,9 +124,10 @@ module.exports = async function emberCliUpdate({
       packageName,
       blueprintName
     );
-    if (existingBlueprint) {
-      blueprint = existingBlueprint;
-    } else {
+
+    blueprint = existingBlueprint;
+
+    if (!existingBlueprint) {
       blueprint = loadSafeBlueprint({
         packageName,
         name: blueprintName,

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const semver = require('semver');
 const getProjectOptions = require('./get-project-options');
 const getPackageName = require('./get-package-name');
 const getVersions = require('boilerplate-update/src/get-versions');
@@ -19,9 +20,17 @@ const findBlueprint = require('./find-blueprint');
 const getBaseBlueprint = require('./get-base-blueprint');
 const chooseBlueprintUpdates = require('./choose-blueprint-updates');
 const getBlueprintFilePath = require('./get-blueprint-file-path');
+const saveBlueprintFile = require('./save-blueprint-file');
 const resolvePackage = require('./resolve-package');
-const { defaultTo } = require('./constants');
+const {
+  defaultTo,
+  defaultPackageName,
+  defaultAppBlueprintName,
+  defaultAppPackageName
+} = require('./constants');
 const normalizeBlueprintArgs = require('./normalize-blueprint-args');
+
+const EMBER_CLI_BLUEPRINT_VITE_BOUNDARY = '6.8.0-beta.1';
 
 /**
  * @typedef {Object} Blueprint

--- a/src/is-default-blueprint.js
+++ b/src/is-default-blueprint.js
@@ -18,6 +18,7 @@ function isDefaultBlueprint({ packageName, name }) {
   if (packageName === glimmerPackageName && name === glimmerPackageName) {
     return true;
   }
+
   return (
     packageName === defaultPackageName &&
     [defaultAppBlueprintName, defaultAddonBlueprintName].includes(name)

--- a/src/load-default-blueprint.js
+++ b/src/load-default-blueprint.js
@@ -13,6 +13,7 @@ function loadDefaultBlueprint(projectOptions = [], version) {
   let packageName = defaultPackageName;
   let name;
   let codemodsSource;
+
   if (projectOptions.includes('addon')) {
     name = defaultAddonBlueprintName;
     codemodsSource = 'ember-addon-codemods-manifest@1';
@@ -25,6 +26,7 @@ function loadDefaultBlueprint(projectOptions = [], version) {
   }
 
   let options = [];
+
   if (!projectOptions.includes('glimmer')) {
     if (projectOptions.includes('yarn')) {
       options.push('--yarn');


### PR DESCRIPTION
Updating the blueprint resolution and update logic to support ember-cli's transition from built-in blueprints to standalone packages (`@ember-tooling/classic-build-app-blueprint` and `@ember-tooling/classic-build-addon-blueprint`). 

- Added constants for new default app and addon blueprint package names
- Enhanced blueprint version resolution to handle custom version ranges (e.g., when updating past published versions)
- Improved `isDefaultAddonBlueprint` detection logic to properly identify new blueprint packages and handle missing keywords
- Automatic blueprint migration: projects updating to ember-cli 6.8.0-beta.1+ with the default `app` blueprint now automatically switch to `@ember-tooling/classic-build-app-blueprint`
- Cleaned up redundant code and improved JSDoc documentation

---

This work is supported by the [Mainmatter Ember Initiative](https://mainmatter.com/ember-initiative/).