### PR TITLE
Purge Node 8 related code

### DIFF
--- a/src/get-start-and-end-commands.js
+++ b/src/get-start-and-end-commands.js
@@ -19,9 +19,6 @@ const nodeModulesIgnore = `
 /node_modules/
 `;
 
-// remove when node 8 is dropped
-const lastNode8Version = '3.16';
-
 module.exports = function getStartAndEndCommands({
   packageJson,
   baseBlueprint,
@@ -68,7 +65,7 @@ module.exports = function getStartAndEndCommands({
     // first version that supports blueprints with versions
     // `-b foo@1.2.3`
     // https://github.com/ember-cli/ember-cli/pull/8571
-    startRange = endRange = `>=3.11.0-beta.1 <${lastNode8Version}`;
+    startRange = endRange = `>=3.11.0-beta.1`;
   }
 
   return {

--- a/test/unit/get-start-and-end-commands-test.js
+++ b/test/unit/get-start-and-end-commands-test.js
@@ -270,7 +270,7 @@ describe(_getStartAndEndCommands, function () {
             name: blueprint,
             version: startVersion
           },
-          packageRange: '>=3.11.0-beta.1 <3.16'
+          packageRange: '>=3.11.0-beta.1'
         },
         endOptions: {
           baseBlueprint: {
@@ -281,7 +281,7 @@ describe(_getStartAndEndCommands, function () {
             name: blueprint,
             version: endVersion
           },
-          packageRange: '>=3.11.0-beta.1 <3.16'
+          packageRange: '>=3.11.0-beta.1'
         }
       });
     });


### PR DESCRIPTION
I must have missed these. We recently dropped support for legacy node versions and this bit of code was still referencing an ancient one.

---

This work is supported by the [Mainmatter Ember Initiative](https://mainmatter.com/ember-initiative/).