### PR TITLE
Move people from the built-in default to `@ember-tooling/classic-build-app-blueprint`

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -7,3 +7,7 @@ module.exports.defaultAddonBlueprintName = 'addon';
 module.exports.glimmerPackageName = '@glimmer/blueprint';
 
 module.exports.defaultTo = '*';
+
+module.exports.EMBER_LEGACY_BLUEPRINT_VERSION = '6.7.0';
+module.exports.CLASSIC_BUILD_APP_BLUEPRINT =
+  '@ember-tooling/classic-build-app-blueprint';

--- a/src/index.js
+++ b/src/index.js
@@ -20,8 +20,15 @@ const getBaseBlueprint = require('./get-base-blueprint');
 const chooseBlueprintUpdates = require('./choose-blueprint-updates');
 const getBlueprintFilePath = require('./get-blueprint-file-path');
 const resolvePackage = require('./resolve-package');
-const { defaultTo } = require('./constants');
+const {
+  defaultTo,
+  defaultAppBlueprintName,
+  defaultPackageName,
+  EMBER_LEGACY_BLUEPRINT_VERSION,
+  CLASSIC_BUILD_APP_BLUEPRINT
+} = require('./constants');
 const normalizeBlueprintArgs = require('./normalize-blueprint-args');
+const semver = require('semver');
 
 /**
  * If `version` attribute exists in the `blueprint` object and URL is empty, skip. Otherwise resolve the details of
@@ -211,6 +218,18 @@ module.exports = async function emberCliUpdate({
         let versions = await getVersions(packageName);
         let getTagVersion = _getTagVersion(versions, packageName);
         endBlueprint.version = await getTagVersion(to);
+
+        if (
+          endBlueprint.isBaseBlueprint &&
+          packageName === defaultPackageName &&
+          endBlueprint.name === defaultAppBlueprintName &&
+          semver.gte(to, EMBER_LEGACY_BLUEPRINT_VERSION)
+        ) {
+          endBlueprint.name = CLASSIC_BUILD_APP_BLUEPRINT;
+          endBlueprint.packageName = CLASSIC_BUILD_APP_BLUEPRINT;
+
+          await _resolvePackage(endBlueprint, packageUrl, to);
+        }
       }
 
       let customDiffOptions = getStartAndEndCommands({

--- a/src/save-blueprint.js
+++ b/src/save-blueprint.js
@@ -2,6 +2,13 @@
 
 const utils = require('./utils');
 const findBlueprint = require('./find-blueprint');
+const {
+  defaultPackageName,
+  defaultAppBlueprintName,
+  EMBER_LEGACY_BLUEPRINT_VERSION,
+  CLASSIC_BUILD_APP_BLUEPRINT
+} = require('./constants');
+const semver = require('semver');
 
 function addBlueprint(emberCliUpdateJson, blueprint) {
   emberCliUpdateJson.blueprints.push(blueprint);
@@ -65,6 +72,19 @@ async function saveBlueprint({ emberCliUpdateJsonPath, blueprint }) {
     addBlueprint(emberCliUpdateJson, savedBlueprint);
   } else {
     savedBlueprint.version = version;
+  }
+
+  if (
+    savedBlueprint.isBaseBlueprint &&
+    packageName === defaultPackageName &&
+    name === defaultAppBlueprintName &&
+    semver.gte(version, EMBER_LEGACY_BLUEPRINT_VERSION)
+  ) {
+    savedBlueprint.name = CLASSIC_BUILD_APP_BLUEPRINT;
+    delete savedBlueprint.packageName;
+    delete savedBlueprint.location;
+    delete savedBlueprint.codemodsSource;
+    delete savedBlueprint.outputRepo;
   }
 
   await utils.saveBlueprintFile(emberCliUpdateJsonPath, emberCliUpdateJson);


### PR DESCRIPTION
This is a new attempt to solve the headache around the special cases that were built around the built-in blueprint.

Goal is to make it easy for people to switch to the new Vite workflow in a standardized way.

---

This work is supported by the [Mainmatter Ember Initiative](https://mainmatter.com/ember-initiative/).