### PR TITLE
Warn users trying to upgrade past 6.7.0 - i.e. don't auto upgrade them to Vite

### DIFF
--- a/docs/upgrading-past-6-7.md
+++ b/docs/upgrading-past-6-7.md
@@ -1,6 +1,6 @@
 # Upgrading your Ember project past 6.7
 
-`ember-cli@6.8.0` is the first release to publish the default app blueprint as
+`ember-cli@6.7.0` is the first release to publish the default app blueprint as
 its own package [@ember-tooling/classic-build-app-blueprint][npm].
 
 [npm]: https://www.npmjs.com/package/@ember-tooling/classic-build-app-blueprint

--- a/docs/upgrading-past-6-7.md
+++ b/docs/upgrading-past-6-7.md
@@ -1,0 +1,49 @@
+# Upgrading your Ember project past 6.7
+
+`ember-cli@6.8.0` is the first release to publish the default app blueprint as
+its own package [@ember-tooling/classic-build-app-blueprint][npm].
+
+[npm]: https://www.npmjs.com/package/@ember-tooling/classic-build-app-blueprint
+
+Starting with `ember@6.8`, creating an Ember application will use the new
+Vite-based blueprint and build process.
+
+## Moving to the new classic app blueprint
+
+If you want to stay with the classic build process, you will need to update
+`config/ember-cli-update.json` and replace the base blueprint:
+
+```diff
+@@ -2,13 +2,11 @@
+{
+  "schemaVersion": "1.0.0",
+  "packages": [
+    {
+-      "name": "ember-cli",
+-      "version": "6.7.0",
++      "name": "@ember-tooling/classic-build-app-blueprint",
++      "version": "6.7.1",
+        "blueprints": [
+          {
+-          "name": "app",
+-          "outputRepo": "https://github.com/ember-cli/ember-new-output",
+-          "codemodsSource": "ember-app-codemods-manifest@1",
++          "name": "@ember-tooling/classic-build-app-blueprint",
+          "isBaseBlueprint": true,
+          "options": [
+            "--ci-provider=github"
+          ]
+        }
+      ]
+    }
+  ]
+}
+```
+
+Re-run `ember-cli-update` after that.
+
+## Moving to Vite
+
+Use [ember-vite-codemod][mod] to upgrade your project.
+
+[mod]: https://github.com/mainmatter/ember-vite-codemod/

--- a/src/index.js
+++ b/src/index.js
@@ -20,8 +20,13 @@ const getBaseBlueprint = require('./get-base-blueprint');
 const chooseBlueprintUpdates = require('./choose-blueprint-updates');
 const getBlueprintFilePath = require('./get-blueprint-file-path');
 const resolvePackage = require('./resolve-package');
-const { defaultTo } = require('./constants');
+const {
+  defaultTo,
+  defaultPackageName,
+  defaultAppBlueprintName
+} = require('./constants');
 const normalizeBlueprintArgs = require('./normalize-blueprint-args');
+const semver = require('semver');
 
 /**
  * If `version` attribute exists in the `blueprint` object and URL is empty, skip. Otherwise resolve the details of
@@ -211,6 +216,18 @@ module.exports = async function emberCliUpdate({
         let versions = await getVersions(packageName);
         let getTagVersion = _getTagVersion(versions, packageName);
         endBlueprint.version = await getTagVersion(to);
+
+        if (
+          packageName === defaultPackageName &&
+          endBlueprint.name === defaultAppBlueprintName &&
+          semver.gte(endBlueprint.version, '6.8.0')
+        ) {
+          console.log(
+            `You cannot use ember-cli-update to automatically upgrade past 6.7. Read the following documentation to find out how to proceed: https://github.com/ember-cli/ember-cli-update/blob/master/docs/upgrading-past-6-7-0.md `
+          );
+
+          process.exit(1);
+        }
       }
 
       let customDiffOptions = getStartAndEndCommands({


### PR DESCRIPTION
We tried automating this, ember-cli-update is too entangled to do so. Needs a link to documentation. 